### PR TITLE
Feat merchant item update/eli

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,4 +7,13 @@ class ItemsController < ApplicationController
       @items = Item.all
     end
   end
+
+  def show
+    if params[:merchant_id]
+      @merchant = Merchant.find(params[:merchant_id])
+      @item = @merchant.items.find(params[:id])
+    else
+      @item = Item.find(params[:id])
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,4 +16,27 @@ class ItemsController < ApplicationController
       @item = Item.find(params[:id])
     end
   end
+
+  def edit
+    @merchant = Merchant.find(params[:merchant_id])
+    @item = @merchant.items.find(params[:id])
+  end
+
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @item = @merchant.items.find(params[:id])
+    if @item.update(item_params)
+      redirect_to "/merchants/#{@merchant.id}/items/#{@item.id}"
+      flash[:message] = "Information successfully updated"
+    else
+      redirect_to "/merchants/#{@merchant.id}/items/#{@item.id}/edit"
+      flash[:error] = "Required content missing or unit price is invalid"
+    end
+  end
+
+  private
+  def item_params
+    params.require(:item).permit(:name, :description, :unit_price)
+  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,4 +5,5 @@ class Item < ApplicationRecord
   has_many :customers, through: :invoices
 
   validates_presence_of :name, :description, :unit_price, :merchant_id
+  validates_numericality_of :unit_price, :greater_than => 0
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,14 @@
+<h4><%="Edit #{@item.name}" %></h4>
+<br>
+
+<%= form_with model: @item, url: merchant_item_path(@merchant, @item), local: true do |form| %>
+<div id="edit_form">
+  <%= form.label "Name:" %>
+  <%= form.text_field :name %>
+  <%= form.label "Description:" %>
+  <%= form.text_field :description %>
+  <%= form.label "Current Selling Price:"%>
+  <%= form.number_field :unit_price %>
+  <%= form.submit "Update Information" %>
+  </div>
+<% end %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -2,13 +2,15 @@
 <br>
 
 <%= form_with model: @item, url: merchant_item_path(@merchant, @item), local: true do |form| %>
-<div id="edit_form">
-  <%= form.label "Name:" %>
-  <%= form.text_field :name %>
-  <%= form.label "Description:" %>
-  <%= form.text_field :description %>
-  <%= form.label "Current Selling Price:"%>
-  <%= form.number_field :unit_price %>
-  <%= form.submit "Update Information" %>
+
+  <div id="edit_form">
+    <%= form.label "Name:" %>
+    <%= form.text_field :name %>
+    <%= form.label "Description:" %>
+    <%= form.text_field :description %>
+    <%= form.label "Current Selling Price:"%>
+    <%= form.number_field :unit_price %>
+    <%= form.submit "Update Information" %>
   </div>
+
 <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,6 +3,6 @@
 <h3>Items:</h3>
 <% @merchant.items.each do |item| %>
   <div id="item-<%= item.id %>">
-    <p><%= item.name %></p>
+    <p><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></p>
   </div>
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,4 @@
 <h3>Item Name: <%= @item.name %></h3>
 <h3>Description: <%= @item.description %></h3>
 <h3>Current Selling Price: $<%= @item.unit_price %></h3>
+<p><%= link_to "Edit Information", "/merchants/#{@merchant.id}/items/#{@item.id}/edit" %></p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,3 @@
+<h3>Item Name: <%= @item.name %></h3>
+<h3>Description: <%= @item.description %></h3>
+<h3>Current Selling Price: $<%= @item.unit_price %></h3>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
   </head>
 
   <body>
+  <% flash.each do |type, message| %>
+      <p><%= message %></p>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get '/merchants/:merchant_id/dashboard', to: 'merchants#show'
 
   resources :merchants, only: [] do
-    resources :items, only: [:index]
+    resources :items, only: [:index, :show]
     resources :invoices, only: [:index]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   get '/merchants/:merchant_id/dashboard', to: 'merchants#show'
 
   resources :merchants, only: [] do
-    resources :items, only: [:index, :show]
+    resources :items, only: [:index, :show, :edit]
     resources :invoices, only: [:index]
   end
+
+  patch "merchants/:merchant_id/items/:id", to: 'items#update'
 end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Items Edit Page" do
+  before :each do
+  @merchant1 = Merchant.create!(name: 'Marvel')
+  @merchant2 = Merchant.create!(name: 'D.C.')
+
+  @item1 = Item.create!(name: 'Beanie Babies', description: 'Investments', unit_price: 100, merchant_id: @merchant1.id)
+  @item2 = Item.create!(name: 'Bat-A-Rangs', description: 'Weapons', unit_price: 500, merchant_id: @merchant2.id)
+  @item3 = Item.create!(name: 'Test', description: 'test', unit_price: 25, merchant_id: @merchant1.id)
+  end
+
+  describe "As a merchant," do
+    describe "When I visit the merchant show page of an item" do
+      it "I see a link to update the item information." do
+        visit "/merchants/#{@merchant1.id}/items/#{@item1.id}"
+        # save_and_open_page
+        expect(page).to have_link("Edit Information")
+      end
+    end
+
+    describe "When I click the link" do
+      it "Then I am taken to a page to edit this item" do
+        visit "/merchants/#{@merchant1.id}/items/#{@item1.id}"
+
+        click_link("Edit Information")
+
+        expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item1.id}/edit")
+      end
+
+      it "And I see a form filled in with the existing item attribute information" do
+        visit "/merchants/#{@merchant1.id}/items/#{@item1.id}/edit"
+          # save_and_open_page
+
+        within("#edit_form") do
+        expect(page).to have_content("Name:")
+        expect(page).to have_field(:item_name)
+
+        expect(page).to have_content("Description:")
+        expect(page).to have_field(:item_description)
+
+        expect(page).to have_content("Current selling price:")
+        expect(page).to have_field(:item_unit_price)
+
+        expect(page).to have_button("Update Information")
+        end
+      end
+
+      describe "When I update the information in the form and I click submit" do
+        it "Then I am redirected back to the item show page where I see the updated information. And I see a flash message stating that the information has been successfully updated." do
+          visit "/merchants/#{@merchant1.id}/items/#{@item1.id}/edit"
+
+          fill_in(:item_description, with: "Stuffed animals that can be an investment")
+
+          click_button('Update Information')
+
+          expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item1.id}")
+
+          expect(page).to have_content("Information successfully updated")
+        end
+      end
+
+      describe "Sad path testing" do
+        it "returns an error if content is missing from the form and redirects back to edit page again" do
+          visit "/merchants/#{@merchant1.id}/items/#{@item1.id}/edit"
+          fill_in(:item_description, with: "")
+          click_button "Update Information"
+
+          expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item1.id}/edit")
+          expect(page).to have_content("Required content missing or unit price is invalid")
+        end
+
+        it "returns an error is unit price is not greater than zero" do
+          visit "/merchants/#{@merchant1.id}/items/#{@item1.id}/edit"
+
+          fill_in(:item_unit_price, with: -25)
+          click_button "Update Information"
+
+          expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item1.id}/edit")
+          expect(page).to have_content("Required content missing or unit price is invalid")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -33,16 +33,16 @@ RSpec.describe "Merchant Items Edit Page" do
           # save_and_open_page
 
         within("#edit_form") do
-        expect(page).to have_content("Name:")
-        expect(page).to have_field(:item_name)
+          expect(page).to have_content("Name:")
+          expect(page).to have_field(:item_name)
 
-        expect(page).to have_content("Description:")
-        expect(page).to have_field(:item_description)
+          expect(page).to have_content("Description:")
+          expect(page).to have_field(:item_description)
 
-        expect(page).to have_content("Current selling price:")
-        expect(page).to have_field(:item_unit_price)
+          expect(page).to have_content("Current selling price:")
+          expect(page).to have_field(:item_unit_price)
 
-        expect(page).to have_button("Update Information")
+          expect(page).to have_button("Update Information")
         end
       end
 

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Merchant Items Index Page" do
       it "I see a list of names of all of my items and do not see items for any other merchant" do
 
       visit "/merchants/#{@merchant1.id}/items"
-      # save_and_open_page
+      #  save_and_open_page
 
       expect(page).to have_content("#{@merchant1.name} Inventory")
 

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -1,0 +1,49 @@
+# As a merchant,
+# When I click on the name of an item from the merchant items index page,
+# Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
+# And I see all of the item's attributes including:
+
+# Name
+# Description
+# Current Selling Price
+require 'rails_helper'
+
+RSpec.describe "Merchant Items Show Page" do
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Marvel')
+    @merchant2 = Merchant.create!(name: 'D.C.')
+
+    @item1 = Item.create!(name: 'Beanie Babies', description: 'Investments', unit_price: 100, merchant_id: @merchant1.id)
+    @item2 = Item.create!(name: 'Bat-A-Rangs', description: 'Weapons', unit_price: 500, merchant_id: @merchant2.id)
+    @item3 = Item.create!(name: 'Test', description: 'test', unit_price: 25, merchant_id: @merchant1.id)
+  end
+
+  describe "As a merchant," do
+    describe "When I click on the name of an item from the merchant items index page," do
+      it "# Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)" do
+        visit "/merchants/#{@merchant1.id}/items"
+
+        within("#item-#{@item1.id}") do
+          expect(page).to have_link("#{@item1.name}")
+        end
+
+        within("#item-#{@item3.id}") do
+          expect(page).to have_link("#{@item3.name}")
+        end
+
+        click_link("#{@item1.name}")
+
+        expect(current_path).to eq("/merchants/#{@merchant1.id}/items/#{@item1.id}")
+      end
+
+      it "And I see all of the item's attributes including: Name, Description, Current Selling Price" do
+
+        visit "/merchants/#{@merchant1.id}/items/#{@item1.id}"
+        # save_and_open_page
+        expect(page).to have_content("Name: #{@item1.name}")
+        expect(page).to have_content("Description: #{@item1.description}")
+        expect(page).to have_content("Current Selling Price: $#{@item1.unit_price}")
+      end
+    end
+  end
+end

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -1,11 +1,3 @@
-# As a merchant,
-# When I click on the name of an item from the merchant items index page,
-# Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
-# And I see all of the item's attributes including:
-
-# Name
-# Description
-# Current Selling Price
 require 'rails_helper'
 
 RSpec.describe "Merchant Items Show Page" do

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -89,9 +89,6 @@ RSpec.describe 'Merchants Dashboard Page' do
           expect(page).to have_content(@customer6.full_name)
         end
       end
-
-      xit 'has the number of successful transactions with the merchant next to each customer' do
-      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of :name }
     it { should validate_presence_of :description }
     it { should validate_presence_of :unit_price }
+    it { should validate_numericality_of(:unit_price).is_greater_than(0) }
     it { should validate_presence_of :merchant_id }
   end
 end


### PR DESCRIPTION
Fix capybarra and orderly issue in merchant show spec
------------------------------------------------------------------------------
complete the following user stories:

As a merchant,
When I click on the name of an item from the merchant items index page,
Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
And I see all of the item's attributes including:

Name
Description
Current Selling Price
-----------------------------------------------------------------------------
As a merchant,
When I visit the merchant show page of an item
I see a link to update the item information.
When I click the link
Then I am taken to a page to edit this item
And I see a form filled in with the existing item attribute information
When I update the information in the form and I click ‘submit’
Then I am redirected back to the item show page where I see the updated information
And I see a flash message stating that the information has been successfully updated.