### PR TITLE
Feat merchant item enable disable/eli

### DIFF
--- a/app/controllers/item_status_controller.rb
+++ b/app/controllers/item_status_controller.rb
@@ -1,0 +1,14 @@
+class ItemStatusController < ApplicationController
+
+  def update
+    @merchant = Merchant.find(params[:merchant_id])
+    @item = @merchant.items.find(params[:id])
+    if params[:enabled]
+      @item.update(:status => 0)
+    redirect_to "/merchants/#{@merchant.id}/items"
+    elsif params[:disabled]
+      @item.update(:status => 1)
+      redirect_to "/merchants/#{@merchant.id}/items"
+    end
+  end
+end

--- a/app/controllers/item_status_controller.rb
+++ b/app/controllers/item_status_controller.rb
@@ -4,10 +4,10 @@ class ItemStatusController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     @item = @merchant.items.find(params[:id])
     if params[:enabled]
-      @item.update(:status => 0)
+      @item.update(:status => 1)
     redirect_to "/merchants/#{@merchant.id}/items"
     elsif params[:disabled]
-      @item.update(:status => 1)
+      @item.update(:status => 0)
       redirect_to "/merchants/#{@merchant.id}/items"
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,7 +48,7 @@ class ItemsController < ApplicationController
       redirect_to "/merchants/#{@merchant.id}/items"
     else
       flash[:error] = "Required content missing or unit price is invalid"
-      render.new
+      redirect_to "/merchants/#{@merchant.id}/items/new"
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   def index
     if params[:merchant_id]
       @merchant = Merchant.find(params[:merchant_id])
-      @items = @merchant.items
+      @enabled_items = @merchant.items.where(status: 1)
+      @disabled_items = @merchant.items.where(status: 0)
     else
       @items = Item.all
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,24 @@ class ItemsController < ApplicationController
     end
   end
 
+  def new
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+
+  def create
+    @merchant = Merchant.find(params[:merchant_id])
+    @item = @merchant.items.new(name: params[:name],
+    description: params[:description],
+  unit_price: params[:unit_price])
+
+    if @item.save
+      redirect_to "/merchants/#{@merchant.id}/items"
+    else
+      flash[:error] = "Required content missing or unit price is invalid"
+      render.new
+    end
+  end
+
   private
   def item_params
     params.require(:item).permit(:name, :description, :unit_price)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,5 +7,5 @@ class Item < ApplicationRecord
   validates_presence_of :name, :description, :unit_price, :merchant_id
   validates_numericality_of :unit_price, :greater_than => 0
 
-  enum status: {enabled: 0, disabled: 1}
+  enum status: {disabled: 0, enabled: 1}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,6 @@ class Item < ApplicationRecord
 
   validates_presence_of :name, :description, :unit_price, :merchant_id
   validates_numericality_of :unit_price, :greater_than => 0
+
+  enum status: {enabled: 0, disabled: 1}
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -18,3 +18,9 @@
 
   </div>
 <% end %>
+
+<br>
+
+<div id= "new_item">
+  <p><%= link_to "Create a New Item", new_merchant_item_path(@merchant) %>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,23 +1,33 @@
 <h1><%= "#{@merchant.name} Inventory" %></h1>
 
-<h3>Items:</h3>
-<% @merchant.items.each do |item| %>
-  <div id="item-<%= item.id %>">
+<section id= "disabled">
+  <h3>Disabled Items:</h3>
+  <% @disabled_items.each do |item| %>
+    <div id="item-<%= item.id %>">
+      <p>
+        <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> Status: <%= item.status %>
+      </p>
+      <p>
+        <%= button_to "Enable", merchant_item_status_path(@merchant, item), method: :patch, params: {enabled: true, item_id: item.id } %>
+      </p>
+    </div>
+  <% end %>
+</section>
 
-    <p>
-      <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> Status: <%= item.status %>
-    </p>
 
-    <p>
-      <%= button_to "Enable", merchant_item_status_path(@merchant, item), method: :patch, params: {enabled: true, item_id: item.id } %>
-    </p>
-
-    <p>
-      <%= button_to "Disable", merchant_item_status_path(@merchant, item), method: :patch, params: {disabled: true, item_id: item.id } %>
-    </p>
-
-  </div>
-<% end %>
+<section id= "enabled">
+  <h3>Enabled Items:</h3>
+  <% @enabled_items.each do |item| %>
+    <div id="item-<%= item.id %>">
+      <p>
+        <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> Status: <%= item.status %>
+      </p>
+      <p>
+        <%= button_to "Disable", merchant_item_status_path(@merchant, item), method: :patch, params: {disabled: true, item_id: item.id } %>
+      </p>
+    </div>
+  <% end %>
+</section>
 
 <br>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,6 +3,18 @@
 <h3>Items:</h3>
 <% @merchant.items.each do |item| %>
   <div id="item-<%= item.id %>">
-    <p><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></p>
+
+    <p>
+      <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %> Status: <%= item.status %>
+    </p>
+
+    <p>
+      <%= button_to "Enable", merchant_item_status_path(@merchant, item), method: :patch, params: {enabled: true, item_id: item.id } %>
+    </p>
+
+    <p>
+      <%= button_to "Disable", merchant_item_status_path(@merchant, item), method: :patch, params: {disabled: true, item_id: item.id } %>
+    </p>
+
   </div>
 <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,7 +1,5 @@
-<h4><%="Edit #{@item.name}" %></h4>
-<br>
-<div id="edit_form">
-  <%= form_with model: @item, url: merchant_item_path(@merchant, @item), local: true do |form| %>
+<div id= "create_item">
+  <%= form_with url: "/merchants/#{@merchant.id}/items", method: :post, local: true do |form| %>
 
     <%= form.label "Name:" %>
     <%= form.text_field :name %>
@@ -9,7 +7,7 @@
     <%= form.text_field :description %>
     <%= form.label "Current Selling Price:"%>
     <%= form.number_field :unit_price %>
-    <%= form.submit "Update Information" %>
+    <%= form.submit "Create Item" %>
 
   <% end %>
- </div>
+</div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,5 +1,5 @@
 <div id= "create_item">
-  <%= form_with url: "/merchants/#{@merchant.id}/items", method: :post, local: true do |form| %>
+  <%= form_with model: @item, url: merchant_items_path(@merchant), local: true do |form| %>
 
     <%= form.label "Name:" %>
     <%= form.text_field :name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get '/merchants/:merchant_id/dashboard', to: 'merchants#show'
 
   resources :merchants, only: [] do
-    resources :items, only: [:index, :show, :edit]
+    resources :items, only: [:index, :show, :edit, :new, :create]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index]
     resources :invoices, only: [:show], controller: 'merchant_invoices'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   resources :merchants, only: [] do
     resources :items, only: [:index, :show, :edit]
+    resources :item_status, only: [:update]
     resources :invoices, only: [:index]
     resources :invoices, only: [:show], controller: 'merchant_invoices'
   end

--- a/db/migrate/20221105144023_add_status_to_items.rb
+++ b/db/migrate/20221105144023_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_31_212534) do
+ActiveRecord::Schema.define(version: 2022_11_05_144023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2022_10_31_212534) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -35,12 +35,10 @@ RSpec.describe 'Merchant Items Index Page' do
         # save_and_open_page
         within("#item-#{@item1.id}") do
           expect(page).to have_button("Enable")
-          expect(page).to have_button("Disable")
         end
 
         within("#item-#{@item3.id}") do
           expect(page).to have_button("Enable")
-          expect(page).to have_button("Disable")
         end
 
       end
@@ -61,11 +59,33 @@ RSpec.describe 'Merchant Items Index Page' do
 
         within("#item-#{@item3.id}") do
           expect(page).to have_content("Status: enabled")
+          expect(page).to have_button("Disable")
           expect(page).to_not have_content("Status: disabled")
         end
 
         within("#item-#{@item1.id}") do
           expect(page).to_not have_content("Status: enabled")
+        end
+      end
+
+      it "Splits enabled and disabled items" do
+        item4 = Item.create!(name: 'Test2', description: 'test', unit_price: 25, status: 1, merchant_id: @merchant1.id)
+
+        visit "/merchants/#{@merchant1.id}/items"
+        #  save_and_open_page
+
+        within("#enabled") do
+          expect(page).to have_content("Enabled Items")
+          expect(page).to have_link("#{item4.name}")
+          expect(page).to_not have_link("#{@item1.name}")
+          expect(page).to have_link("#{@item3.name}")
+        end
+
+        within("#disabled") do
+          expect(page).to have_content("Disabled Items")
+          expect(page).to have_link("#{@item1.name}")
+          expect(page).to have_link("#{@item3.name}")
+          expect(page).to_not have_link("#{item4.name}")
         end
       end
     end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe 'Merchant Items Index Page' do
       it "Redirects back to the merchant items index and updates status based on which button is clicked" do
         visit "/merchants/#{@merchant1.id}/items"
 
+        within("#item-#{@item1.id}") do
+          expect(page).to have_content("Status: disabled")
+        end
+
         within("#item-#{@item3.id}") do
           expect(page).to have_content("Status: disabled")
           click_button("Enable")
@@ -57,8 +61,12 @@ RSpec.describe 'Merchant Items Index Page' do
 
         within("#item-#{@item3.id}") do
           expect(page).to have_content("Status: enabled")
+          expect(page).to_not have_content("Status: disabled")
         end
 
+        within("#item-#{@item1.id}") do
+          expect(page).to_not have_content("Status: enabled")
+        end
       end
     end
   end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -29,6 +29,37 @@ RSpec.describe 'Merchant Items Index Page' do
           expect(page).to have_content(@item3.name)
         end
       end
+
+      it "Next to each item name I see a button to disable or enable that item." do
+        visit "/merchants/#{@merchant1.id}/items"
+        # save_and_open_page
+        within("#item-#{@item1.id}") do
+          expect(page).to have_button("Enable")
+          expect(page).to have_button("Disable")
+        end
+
+        within("#item-#{@item3.id}") do
+          expect(page).to have_button("Enable")
+          expect(page).to have_button("Disable")
+        end
+
+      end
+
+      it "Redirects back to the merchant items index and updates status based on which button is clicked" do
+        visit "/merchants/#{@merchant1.id}/items"
+
+        within("#item-#{@item3.id}") do
+          expect(page).to have_content("Status: enabled")
+          click_button("Disable")
+        end
+
+        expect(current_path).to eq("/merchants/#{@merchant1.id}/items")
+
+        within("#item-#{@item3.id}") do
+          expect(page).to have_content("Status: disabled")
+        end
+
+      end
     end
   end
 end

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -49,14 +49,14 @@ RSpec.describe 'Merchant Items Index Page' do
         visit "/merchants/#{@merchant1.id}/items"
 
         within("#item-#{@item3.id}") do
-          expect(page).to have_content("Status: enabled")
-          click_button("Disable")
+          expect(page).to have_content("Status: disabled")
+          click_button("Enable")
         end
 
         expect(current_path).to eq("/merchants/#{@merchant1.id}/items")
 
         within("#item-#{@item3.id}") do
-          expect(page).to have_content("Status: disabled")
+          expect(page).to have_content("Status: enabled")
         end
 
       end

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe "Merchant Item New Page" do
+
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Marvel')
+    @merchant2 = Merchant.create!(name: 'D.C.')
+
+    @item1 = Item.create!(name: 'Beanie Babies', description: 'Investments', unit_price: 100, merchant_id: @merchant1.id)
+    @item2 = Item.create!(name: 'Bat-A-Rangs', description: 'Weapons', unit_price: 500, merchant_id: @merchant2.id)
+    @item3 = Item.create!(name: 'Test', description: 'test', unit_price: 25, merchant_id: @merchant1.id)
+  end
+
+  describe "As a merchant" do
+    describe "When I visit my items index page" do
+      it "I see a link to create a new item" do
+        visit "/merchants/#{@merchant1.id}/items"
+        # save_and_open_page
+        within("#new_item") do
+          expect(page).to have_link("Create a New Item")
+        end
+      end
+
+      describe "When I click the link" do
+        it "I am taken to a form that allows me to add item information" do
+          visit "/merchants/#{@merchant1.id}/items"
+
+          click_link("Create a New Item")
+
+          expect(current_path).to eq("/merchants/#{@merchant1.id}/items/new")
+
+          within("#create_item") do
+            expect(page).to have_content("Name:")
+            expect(page).to have_field(:name)
+            expect(page).to have_content("Description:")
+            expect(page).to have_field(:description)
+            expect(page).to have_content("Current selling price:")
+            expect(page).to have_field(:unit_price)
+            expect(page).to have_button("Create Item")
+          end
+        end
+      end
+
+      describe "When I fill out the form I click Submit" do
+        it "Then I am taken back to the items index page And I see the item I just created displayed in the list of items. And I see my item was created with a default status of disabled." do
+
+          visit "/merchants/#{@merchant1.id}/items/new"
+
+          fill_in(:name, with: "Boots")
+          fill_in(:description, with: "Made for walking")
+          fill_in(:unit_price, with: 150)
+          click_button("Create Item")
+
+          expect(current_path).to eq("/merchants/#{@merchant1.id}/items")
+
+          within("#item-#{@merchant1.items.last.id}") do
+            expect(page).to have_link("Boots")
+            expect(page).to have_content("Status: disabled")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe "Merchant Item New Page" do
           end
         end
       end
+
+      describe "Sad path testing :(" do
+        it "returns an error if content is missing from the form and redirects back to new page again" do
+          visit "/merchants/#{@merchant1.id}/items/new"
+
+          click_button("Create Item")
+
+          expect(current_path).to eq("/merchants/#{@merchant1.id}/items/new")
+          expect(page).to have_content("Required content missing or unit price is invalid")
+          # save_and_open_page
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Completed the following:

As a merchant
When I visit my items index page
Next to each item name I see a button to disable or enable that item.
When I click this button
Then I am redirected back to the items index
And I see that the items status has changed
---------------------------------------------------------------------

As a merchant,
When I visit my merchant items index page
Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
And I see that each Item is listed in the appropriate section
------------------------------------------------------------------------
As a merchant
When I visit my items index page
I see a link to create a new item.
When I click on the link,
I am taken to a form that allows me to add item information.
When I fill out the form I click ‘Submit’
Then I am taken back to the items index page
And I see the item I just created displayed in the list of items.
And I see my item was created with a default status of disabled.