### PR TITLE
Feat: delete a discount from merchant

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -22,6 +22,12 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    discount = BulkDiscount.find(params[:id])
+    discount.destroy
+    redirect_to merchant_bulk_discounts_path(discount.merchant)
+  end
+
   private
 
   def bulk_discount_params

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,6 +6,7 @@
     <p>Discount ID: <%= link_to "#{discount.id}", "/merchants/#{@merchant.id}/bulk_discounts/#{discount.id}" %></p>
     <li>Percentage: <%= discount.percentage %>%</li>
     <li>Threshold: <%= discount.quantity_threshold %></li>
+    <%= button_to "Delete Discount: #{discount.id}", "/merchants/#{@merchant.id}/bulk_discounts/#{discount.id}", method: :delete %>
   <% end %>
   </ol>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,6 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :show, :edit, :new, :create]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 end

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -127,4 +127,28 @@ RSpec.describe 'bulk discounts index page of merchant' do
       expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts/#{@discount_1.id}")
     end
   end
+
+  it 'has a button to delete a discount for that merchant' do
+    visit merchant_bulk_discounts_path(@merchant_1)
+
+    within("#discounts") do
+      expect(page).to have_button("Delete Discount: #{@discount_1.id}")
+      expect(page).to have_button("Delete Discount: #{@discount_2.id}")
+      expect(page).to_not have_button("Delete Discount: #{@discount_3.id}")
+
+      click_on "Delete Discount: #{@discount_1.id}"
+    end
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant_1))
+
+    within("#discounts") do
+      expect(page).to_not have_content("Percentage: #{@discount_1.percentage}")
+      expect(page).to_not have_content("Threshold: #{@discount_1.quantity_threshold}")  
+      expect(page).to_not have_button("Delete Discount: #{@discount_1.id}")
+      expect(page).to have_content("Percentage: #{@discount_2.percentage}")
+      expect(page).to have_content("Threshold: #{@discount_2.quantity_threshold}")
+      expect(page).to have_button("Delete Discount: #{@discount_2.id}")
+      expect(page).to_not have_button("Delete Discount: #{@discount_3.id}")
+    end
+  end
 end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed

All tests pass
Coverage: 100%