### PR TITLE
Feat: Edit a bulk discount for a merchant

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -8,6 +8,7 @@ class BulkDiscountsController < ApplicationController
   end
 
   def new
+    @discount = BulkDiscount.new
     @merchant = Merchant.find(params[:merchant_id])
   end
 
@@ -26,6 +27,20 @@ class BulkDiscountsController < ApplicationController
     discount = BulkDiscount.find(params[:id])
     discount.destroy
     redirect_to merchant_bulk_discounts_path(discount.merchant)
+  end
+
+  def edit
+    @discount = BulkDiscount.find(params[:id])
+  end
+
+  def update
+    discount = BulkDiscount.find(params[:id])
+    if discount.update(bulk_discount_params)
+      redirect_to merchant_bulk_discount_path(discount.merchant, discount)
+    else
+      redirect_to edit_merchant_bulk_discount_path(discount.merchant, discount)
+      flash[:alert] = "Error! Please update fields with content"
+    end
   end
 
   private

--- a/app/views/bulk_discounts/_form.html.erb
+++ b/app/views/bulk_discounts/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @bulk_discount, url: path, local: true do |f| %>
+<%= form_with model: @bulk_discount, url: path, method: method, local: true do |f| %>
   <%= f.label :percentage, "Percentage" %>
   <%= f.number_field :percentage, in: 1..100, step: 1 %>
   <%= f.label :quantity_threshold, "Item Threshold" %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>Edit <%= @discount.id %></h1>
+
+<%= render partial: 'form', locals: {path: merchant_bulk_discount_path(@discount.merchant, @discount), method: :patch, button_text: "Update Discount"} %>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,3 +1,3 @@
 <h1>Create a new Discount</h1>
 
-<%= render partial: 'form', locals: {path: merchant_bulk_discounts_path(@merchant), button_text: "Create Discount"} %>
+<%= render partial: 'form', locals: {path: merchant_bulk_discounts_path(@merchant), method: :post, button_text: "Create Discount"} %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -2,3 +2,5 @@
 
 <p>Percent Discount: <%= @discount.percentage %></p>
 <p>Quantity Threshold: <%= @discount.quantity_threshold %></p>
+
+<%= button_to "Edit Discount", edit_merchant_bulk_discount_path(@discount.merchant, @discount), method: :get %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,6 @@ Rails.application.routes.draw do
     resources :items, only: [:index, :show, :edit, :new, :create]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
   end
 end

--- a/spec/features/merchants/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchants/bulk_discounts/edit_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'bulk discounts edit' do
+  before :each do
+    @merchant_1 = Merchant.create!(name: 'Marvel', status: 'enabled')
+    @merchant_2 = Merchant.create!(name: 'D.C.', status: 'disabled')
+    @merchant_3 = Merchant.create!(name: 'Darkhorse', status: 'enabled')
+    @merchant_4 = Merchant.create!(name: 'Image', status: 'disabled')
+    @merchant_5 = Merchant.create!(name: 'Wonders', status: 'enabled')
+    @merchant_6 = Merchant.create!(name: 'Disney', status: 'enabled')
+
+    @discount_1 = BulkDiscount.create!(percentage: 15, quantity_threshold: 5, merchant_id: @merchant_1.id)
+    @discount_2 = BulkDiscount.create!(percentage: 20, quantity_threshold: 10, merchant_id: @merchant_1.id)
+    @discount_3 = BulkDiscount.create!(percentage: 10, quantity_threshold: 2, merchant_id: @merchant_2.id)
+  end
+
+  it 'has a link to edit the discount on the show page' do
+    visit merchant_bulk_discount_path(@merchant_1, @discount_1)
+
+    expect(page).to have_button("Edit Discount")
+
+    click_on "Edit Discount"
+
+    expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant_1, @discount_1))
+    fill_in :percentage, with: 12
+    fill_in :quantity_threshold, with: 5
+    click_on "Update Discount"
+
+    expect(current_path).to eq(merchant_bulk_discount_path(@merchant_1, @discount_1))
+    expect(page).to have_content("Percent Discount: 12")
+    expect(page).to_not have_content("Percent Discount: #{@discount_1.percentage}")
+    expect(page).to have_content("Quantity Threshold: #{@discount_1.quantity_threshold}")
+  end
+
+  it 'displays an error message if no content is put into form' do
+    visit edit_merchant_bulk_discount_path(@merchant_1, @discount_1)
+
+    fill_in :percentage, with: ""
+    fill_in :quantity_threshold, with: 5
+    click_on "Update Discount"
+
+    expect(page).to have_content("Error! Please update fields with content")
+  end
+end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated

All tests pass
100% Coverage