### PR TITLE
Total revenue and discounted revenue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :get_all
+  # before_action :get_all
   def get_all
     # @repo_name = GithubService.new.repo_name
     # @users = GithubService.new.users

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -4,17 +4,37 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :bulk_discounts, through: :merchants
   validates_presence_of :status, :customer_id
 
   enum status: { 'in progress' => 0, completed: 1, cancelled: 2 }
 
-  def total_revenue
+  def all_revenue
     invoice_items.sum('unit_price * quantity')
+  end
+  
+  def total_revenue(merchant)
+    invoice_items
+      .joins(item: :merchant)
+      .where("items.merchant_id = #{merchant.id}")  
+      .sum('invoice_items.unit_price * invoice_items.quantity')
   end
 
   def self.incomplete_invoices
     joins(:invoice_items)
       .where('invoice_items.status=0 OR invoice_items.status=1')
       .order(:created_at)
+  end
+
+  def decimal_discount
+    percentage.to_f / 100
+  end
+
+  def revenue_with_discount(merchant)
+    invoice_items
+      .joins(item: {merchant: :bulk_discounts})
+      .where("invoice_items.quantity >= bulk_discounts.quantity_threshold AND items.merchant_id = #{merchant.id}")
+      # .group(:id)
+      .sum('(invoice_items.quantity * invoice_items.unit_price) - (invoice_items.quantity * invoice_items.unit_price * (bulk_discounts.percentage / 100))')
   end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -26,4 +26,4 @@
     </div>
 <% end %>
 <br>
-<h2>Total Revenue of All Items: <%= @invoice.total_revenue %></h2>
+<h2>Total Revenue of All Items: <%= @invoice.all_revenue %></h2>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -21,5 +21,6 @@
 <br>
 
 <div id="total_invoice_revenue">
-  <p><b>Total Invoice Revenue: </b><%= "#{@invoice.total_revenue}¢"%>
+  <p><b>Total Invoice Revenue: </b><%= @invoice.total_revenue(@merchant) %>
+  <p>Total Invoice Revenue with Discounts: <%= @invoice.revenue_with_discount(@merchant) %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,19 +14,7 @@
   <% flash.each do |type, message| %>
       <p><%= message %></p>
     <% end %>
-    <section>
 
-      <h3>Contributors: </h3>
-      <% @users.each do |user| %>
-        <p><%= user[:name] %> - Commits: <%= user[:commits] %></p>
-      <% end %>
-
-      <h3>Repository Name: </h3>
-        <p><%= @repo_name %></p>
-
-      <h3>Total Pull Requests: </h3>
-        <p><%= @pr_count %></p>
-    </section>
     <%= yield %>
   </body>
 </html>

--- a/db/migrate/20221111144943_create_bulk_discounts.rb
+++ b/db/migrate/20221111144943_create_bulk_discounts.rb
@@ -1,7 +1,7 @@
 class CreateBulkDiscounts < ActiveRecord::Migration[5.2]
   def change
     create_table :bulk_discounts do |t|
-      t.integer :percentage
+      t.float :percentage
       t.integer :quantity_threshold
       t.references :merchant, foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 2022_11_11_144943) do
   enable_extension "plpgsql"
 
   create_table "bulk_discounts", force: :cascade do |t|
-    t.integer "percentage"
+    t.float "percentage"
     t.integer "quantity_threshold"
     t.bigint "merchant_id"
     t.datetime "created_at", null: false

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -1,102 +1,143 @@
 require 'rails_helper'
 
 RSpec.describe 'Merchant Invoice Show Page' do
-  before :each do
-    @merchant1 = Merchant.create!(name: 'Marvel')
-    @merchant2 = Merchant.create!(name: 'Honey Bee', status: 'enabled')
+  describe 'merchant show page - no discounts' do  
+    before :each do
+      @merchant1 = Merchant.create!(name: 'Marvel')
+      @merchant2 = Merchant.create!(name: 'Honey Bee', status: 'enabled')
 
-    @customer1 = Customer.create!(first_name: 'Peter', last_name: 'Parker')
+      @customer1 = Customer.create!(first_name: 'Peter', last_name: 'Parker')
 
-    @item1 = Item.create!(name: 'Beanie Babies', description: 'Investments', unit_price: 100, merchant_id: @merchant1.id)
-    @item2 = Item.create!(name: 'Bat-A-Rangs', description: 'Weapons', unit_price: 100, merchant_id: @merchant1.id)
-    @item3 = Item.create!(name: 'Bat Mask', description: 'Identity Protection', unit_price: 800, merchant_id: @merchant2.id)
+      @item1 = Item.create!(name: 'Beanie Babies', description: 'Investments', unit_price: 100, merchant_id: @merchant1.id)
+      @item2 = Item.create!(name: 'Bat-A-Rangs', description: 'Weapons', unit_price: 100, merchant_id: @merchant1.id)
+      @item3 = Item.create!(name: 'Bat Mask', description: 'Identity Protection', unit_price: 800, merchant_id: @merchant2.id)
 
-    @invoice1 = Invoice.create!(status: 'completed', customer_id: @customer1.id, created_at: Time.parse('19.07.18'))
-    @invoice2 = Invoice.create!(status: 'completed', customer_id: @customer1.id, created_at: '2010-03-11 01:51:45')
+      @invoice1 = Invoice.create!(status: 'completed', customer_id: @customer1.id, created_at: Time.parse('19.07.18'))
+      @invoice2 = Invoice.create!(status: 'completed', customer_id: @customer1.id, created_at: '2010-03-11 01:51:45')
 
-    InvoiceItem.create!(quantity: 5, unit_price: 100, status: 'packaged', item_id: @item1.id, invoice_id: @invoice1.id)
-    InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item_id: @item2.id, invoice_id: @invoice1.id)
-    InvoiceItem.create!(quantity: 50, unit_price: 800, status: 'shipped', item_id: @item3.id, invoice_id: @invoice2.id)
+      InvoiceItem.create!(quantity: 5, unit_price: 100, status: 'packaged', item_id: @item1.id, invoice_id: @invoice1.id)
+      InvoiceItem.create!(quantity: 15, unit_price: 100, status: 'packaged', item_id: @item2.id, invoice_id: @invoice1.id)
+      InvoiceItem.create!(quantity: 50, unit_price: 800, status: 'shipped', item_id: @item3.id, invoice_id: @invoice2.id)
+    end
+
+    describe 'As a merchant' do
+      describe "When I visit my merchant's invoice show page" do
+        it "I see information related to that invoice including: Invoice id, Invoice status, Invoice created_at date in the format 'Monday, July 18, 2019', Customer first and last name" do
+          visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
+
+          expect(page).to have_content("ID: #{@invoice1.id}")
+          expect(page).to have_content("Status: #{@invoice1.status}")
+          expect(page).to have_content('Created: Thursday, July 18, 2019')
+          expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
+        end
+
+        it 'Then I see all of my items on the invoice including: Item name, The quantity of the item ordered, The price the Item sold for, The Invoice Item status, And I do not see any information related to Items for other merchants' do
+          visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
+
+          within("#item-#{@item2.id}") do
+            expect(page).to have_content("Name: #{@item2.name}")
+            expect(page).to have_content("Price: #{@item2.unit_price}")
+            expect(page).to have_content('Quantity: 15')
+            expect(page).to have_content('Status: packaged')
+          end
+
+          within("#item-#{@item1.id}") do
+            expect(page).to have_content("Name: #{@item1.name}")
+            expect(page).to have_content("Price: #{@item1.unit_price}")
+            expect(page).to have_content('Quantity: 5')
+            expect(page).to have_content('Status: packaged')
+          end
+
+          expect(page).to_not have_content(@item3.name)
+        end
+
+        it 'I see the total revenue that will be generated from all of my items on the invoice' do
+          visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
+
+          within('#total_invoice_revenue') do
+            expect(page).to have_content('Total Invoice Revenue: 2000')
+          end
+        end
+
+        it 'has a select field with current status that can be changed to update status' do
+          visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
+
+          within("#item-#{@item1.id}") do
+            expect(page).to have_selector(:css, 'form')
+            expect(find('form')).to have_content("#{@item1.invoice_items.first.status}")
+            expect(@item1.invoice_items.first.status).to eq('packaged')
+
+            expect(page).to have_button('Update Item Status')
+
+            select('shipped', from: 'Status')
+            click_button('Update Item Status')
+
+            expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}")
+            expect(@item1.invoice_items.first.status).to eq('shipped')
+            expect(find('form')).to have_content('shipped')
+          end
+
+          within("#item-#{@item2.id}") do
+            expect(page).to have_selector(:css, 'form')
+            expect(find('form')).to have_content("#{@item2.invoice_items.first.status}")
+            expect(@item2.invoice_items.first.status).to eq('packaged')
+
+            expect(page).to have_button('Update Item Status')
+
+            select('pending', from: 'Status')
+            click_button('Update Item Status')
+
+            expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}")
+            expect(@item2.invoice_items.first.status).to eq('pending')
+            expect(find('form')).to have_content('pending')
+
+            select('packaged', from: 'Status')
+            click_button('Update Item Status')
+
+            expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}")
+            expect(@item2.invoice_items.first.status).to eq('packaged')
+            expect(find('form')).to have_content('packaged')
+          end
+        end
+      end
+    end
   end
 
-  describe 'As a merchant' do
-    describe "When I visit my merchant's invoice show page(/merchants/merchant_id/invoices/invoice_id)" do
-      it "Then I see information related to that invoice including: Invoice id, Invoice status, Invoice created_at date in the format 'Monday, July 18, 2019', Customer first and last name" do
-        visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
+  describe 'merchant bulk discount applied' do
+    before(:each) do
+      @merchant_1 = Merchant.create!(name: 'Marvel', status: 'enabled')
+      @merchant_2 = Merchant.create!(name: 'D.C.', status: 'disabled')
+      
+      @discount_1 = BulkDiscount.create!(percentage: 15, quantity_threshold: 5, merchant_id: @merchant_1.id)
+      @discount_2 = BulkDiscount.create!(percentage: 20, quantity_threshold: 10, merchant_id: @merchant_1.id)
+      @discount_3 = BulkDiscount.create!(percentage: 10, quantity_threshold: 2, merchant_id: @merchant_2.id)
+      
+      @customer1 = Customer.create!(first_name: 'Peter', last_name: 'Parker')
+      @customer2 = Customer.create!(first_name: 'Clark', last_name: 'Kent') 
+      
+      @invoice1 = Invoice.create!(status: 'completed', customer_id: @customer1.id, created_at: Time.parse('21.01.28'))
+      @invoice2 = Invoice.create!(status: 'completed', customer_id: @customer2.id, created_at: Time.parse('22.08.22'))
+      
+      @item1 = Item.create!(name: 'Beanie Babies', description: 'Investments', unit_price: 100, merchant_id: @merchant_1.id)
+      @item2 = Item.create!(name: 'Bat-A-Rangs', description: 'Weapons', unit_price: 500, merchant_id: @merchant_2.id)
+      
+      InvoiceItem.create!(quantity: 5, unit_price: 500, status: 'packaged', item_id: @item1.id, invoice_id: @invoice1.id)
+      InvoiceItem.create!(quantity: 1, unit_price: 100, status: 'shipped', item_id: @item1.id, invoice_id: @invoice2.id)
+      
+      InvoiceItem.create!(quantity: 50, unit_price: 5000, status: 'shipped', item_id: @item2.id, invoice_id: @invoice1.id)
+      InvoiceItem.create!(quantity: 15, unit_price: 1500, status: 'shipped', item_id: @item2.id, invoice_id: @invoice2.id)
+      
+      @transaction1 = Transaction.create!(credit_card_number: '4801647818676136', credit_card_expiration_date: nil, result: 'failed', invoice_id: @invoice1.id)
+      @transaction2 = Transaction.create!(credit_card_number: '4654405418249632', credit_card_expiration_date: nil, result: 'success', invoice_id: @invoice1.id)
+      @transaction3 = Transaction.create!(credit_card_number: '4800749911485986', credit_card_expiration_date: nil, result: 'success', invoice_id: @invoice2.id)
+    end
 
-        expect(page).to have_content("ID: #{@invoice1.id}")
-        expect(page).to have_content("Status: #{@invoice1.status}")
-        expect(page).to have_content('Created: Thursday, July 18, 2019')
-        expect(page).to have_content("Customer: #{@invoice1.customer.full_name}")
-      end
+    it 'has total revenue and discounted revenue for that invoice' do
+      visit merchant_invoice_path(@merchant_1, @invoice1)
 
-      it 'Then I see all of my items on the invoice including: Item name, The quantity of the item ordered, The price the Item sold for, The Invoice Item status, And I do not see any information related to Items for other merchants' do
-        visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
-
-        within("#item-#{@item2.id}") do
-          expect(page).to have_content("Name: #{@item2.name}")
-          expect(page).to have_content("Price: #{@item2.unit_price}")
-          expect(page).to have_content('Quantity: 15')
-          expect(page).to have_content('Status: packaged')
-        end
-
-        within("#item-#{@item1.id}") do
-          expect(page).to have_content("Name: #{@item1.name}")
-          expect(page).to have_content("Price: #{@item1.unit_price}")
-          expect(page).to have_content('Quantity: 5')
-          expect(page).to have_content('Status: packaged')
-        end
-
-        expect(page).to_not have_content(@item3.name)
-      end
-
-      it 'I see the total revenue that will be generated from all of my items on the invoice' do
-        visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
-
-        within('#total_invoice_revenue') do
-          expect(page).to have_content('Total Invoice Revenue: 2000¢')
-        end
-      end
-
-      it 'has a select field with current status that can be changed to update status' do
-        visit "/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}"
-
-        within("#item-#{@item1.id}") do
-          expect(page).to have_selector(:css, 'form')
-          expect(find('form')).to have_content("#{@item1.invoice_items.first.status}")
-          expect(@item1.invoice_items.first.status).to eq('packaged')
-
-          expect(page).to have_button('Update Item Status')
-
-          select('shipped', from: 'Status')
-          click_button('Update Item Status')
-
-          expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}")
-          expect(@item1.invoice_items.first.status).to eq('shipped')
-          expect(find('form')).to have_content('shipped')
-        end
-
-        within("#item-#{@item2.id}") do
-          expect(page).to have_selector(:css, 'form')
-          expect(find('form')).to have_content("#{@item2.invoice_items.first.status}")
-          expect(@item2.invoice_items.first.status).to eq('packaged')
-
-          expect(page).to have_button('Update Item Status')
-
-          select('pending', from: 'Status')
-          click_button('Update Item Status')
-
-          expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}")
-          expect(@item2.invoice_items.first.status).to eq('pending')
-          expect(find('form')).to have_content('pending')
-
-          select('packaged', from: 'Status')
-          click_button('Update Item Status')
-
-          expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice1.id}")
-          expect(@item2.invoice_items.first.status).to eq('packaged')
-          expect(find('form')).to have_content('packaged')
-        end
+      within("#total_invoice_revenue") do
+        expect(page).to have_content("Total Invoice Revenue: 2500")
+        expect(page).to have_content("Total Invoice Revenue with Discounts: 2125.0")
       end
     end
   end

--- a/spec/features/merchants/bulk_discounts/new_spec.rb
+++ b/spec/features/merchants/bulk_discounts/new_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'bulk discounts index page of merchant' do
     expect(current_path).to eq("/merchants/#{@merchant_1.id}/bulk_discounts")
     
     within("#discounts") do
-      expect(page).to have_content("Percentage: 10%")
+      expect(page).to have_content("Percentage: 10.0%")
       expect(page).to have_content("Threshold: 3")
     end
   end


### PR DESCRIPTION
6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation

All tests pass 
Coverage: 99.79% (API not covered)

Maybe refactor the model method for multiple discounts