### PR TITLE
Add holidays api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,10 @@ group :development, :test do
   gem 'pry-nav'
 end
 
+group :test do
+  gem 'webmock'
+end
+
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     diff-lcs (1.5.0)
     docile (1.4.0)
@@ -75,6 +77,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -155,6 +158,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.6.0)
+    rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -222,6 +226,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -256,6 +264,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
 
 RUBY VERSION
    ruby 2.7.4p191

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,6 +1,8 @@
 class BulkDiscountsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
+    @holiday_names = HolidayService.holiday_name
+    @holiday_dates = HolidayService.holiday_date
   end
 
   def show

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,16 @@
+require 'httparty'
+
+class HolidayService
+  def self.holidays_data
+    response = HTTParty.get("https://date.nager.at/api/v3/NextPublicHolidays/us")
+    parsed_json = JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.holiday_name
+    holidays_data[0..2].map { |holiday| holiday[:name] }
+  end
+
+  def self.holiday_date
+    holidays_data[0..2].map { |holiday| holiday[:date] }
+  end
+end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,14 +1,21 @@
 <h1><%= @merchant.name %>'s Discounts</h1>
 
+<h3>Upcoming Holidays: </h3>
+<li><%= @holiday_names.first %> - <%= @holiday_dates.first %></li>
+<li><%= @holiday_names.second %> - <%= @holiday_dates.second %></li>
+<li><%= @holiday_names.third %> - <%= @holiday_dates.third %></li>
+
+<br>
+
 <%= link_to "Create New Discount", "/merchants/#{@merchant.id}/bulk_discounts/new" %>
 
 <div id="discounts">
-  <ol>
+  <ul>
   <% @merchant.bulk_discounts.each do |discount| %>
     <p>Discount ID: <%= link_to "#{discount.id}", "/merchants/#{@merchant.id}/bulk_discounts/#{discount.id}" %></p>
     <li>Percentage: <%= discount.percentage %>%</li>
     <li>Threshold: <%= discount.quantity_threshold %></li>
     <%= button_to "Delete Discount: #{discount.id}", merchant_bulk_discount_path(@merchant, discount), method: :delete %>
   <% end %>
-  </ol>
+  </ul>
 </div>

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -157,4 +157,24 @@ RSpec.describe 'bulk discounts index page of merchant' do
 
     expect(page).to have_link("Create New Discount")
   end
+
+  let(:holiday_response) { HolidayService.holiday_name }
+  
+  it 'has the next 3 upcoming holidays' do
+    visit merchant_bulk_discounts_path(@merchant_1)
+
+    expect(page).to have_content("Thanksgiving Day")
+    expect(page).to have_content("Christmas Day")
+    expect(page).to have_content("New Year's Day")
+  end
+
+  let(:holiday_response) { HolidayService.holiday_date }
+
+  it 'has the next 3 upcoming holidays dates' do
+    visit merchant_bulk_discounts_path(@merchant_1)
+
+    expect(page).to have_content("2022-11-24")
+    expect(page).to have_content("2022-12-26")
+    expect(page).to have_content("2023-01-02")
+  end
 end

--- a/spec/services/holiday_spec.rb
+++ b/spec/services/holiday_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe HolidayService do
+  describe 'holidays' do
+    let(:holiday_response) { HolidayService.holidays_data }
+
+    it 'returns the names of next 3 holidays' do
+      expect(holiday_response).to be_kind_of(Array)
+      expect(holiday_response[0]).to have_key(:name)
+      expect(holiday_response[0]).to have_key(:date)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,218 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'webmock/rspec'
+
 RSpec.configure do |config|
+
+  config.before(:each) do
+    holiday_response = [
+      {
+          "date": "2022-11-24",
+          "localName": "Thanksgiving Day",
+          "name": "Thanksgiving Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": 1863,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2022-12-26",
+          "localName": "Christmas Day",
+          "name": "Christmas Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-01-02",
+          "localName": "New Year's Day",
+          "name": "New Year's Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-01-16",
+          "localName": "Martin Luther King, Jr. Day",
+          "name": "Martin Luther King, Jr. Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-02-20",
+          "localName": "Presidents Day",
+          "name": "Washington's Birthday",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-04-07",
+          "localName": "Good Friday",
+          "name": "Good Friday",
+          "countryCode": "US",
+          "fixed": false,
+          "global": false,
+          "counties": [
+              "US-CT",
+              "US-DE",
+              "US-HI",
+              "US-IN",
+              "US-KY",
+              "US-LA",
+              "US-NC",
+              "US-ND",
+              "US-NJ",
+              "US-TN"
+          ],
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-05-29",
+          "localName": "Memorial Day",
+          "name": "Memorial Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-06-19",
+          "localName": "Juneteenth",
+          "name": "Juneteenth",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": 2021,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-07-04",
+          "localName": "Independence Day",
+          "name": "Independence Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-09-04",
+          "localName": "Labor Day",
+          "name": "Labour Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-10-09",
+          "localName": "Columbus Day",
+          "name": "Columbus Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": false,
+          "counties": [
+              "US-AL",
+              "US-AZ",
+              "US-CO",
+              "US-CT",
+              "US-DC",
+              "US-GA",
+              "US-ID",
+              "US-IL",
+              "US-IN",
+              "US-IA",
+              "US-KS",
+              "US-KY",
+              "US-LA",
+              "US-ME",
+              "US-MD",
+              "US-MA",
+              "US-MS",
+              "US-MO",
+              "US-MT",
+              "US-NE",
+              "US-NH",
+              "US-NJ",
+              "US-NM",
+              "US-NY",
+              "US-NC",
+              "US-OH",
+              "US-OK",
+              "US-PA",
+              "US-RI",
+              "US-SC",
+              "US-TN",
+              "US-UT",
+              "US-VA",
+              "US-WV"
+          ],
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      },
+      {
+          "date": "2023-11-10",
+          "localName": "Veterans Day",
+          "name": "Veterans Day",
+          "countryCode": "US",
+          "fixed": false,
+          "global": true,
+          "counties": nil,
+          "launchYear": nil,
+          "types": [
+              "Public"
+          ]
+      }
+  ]
+
+    stub_request(:get, "https://date.nager.at/api/v3/NextPublicHolidays/us").to_return(status: 200, body: holiday_response.to_json)
+  end
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
9: Holidays API

As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)

all tests pass
Coverage: 100%